### PR TITLE
Making debugging gems optional in dev environment.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,6 +53,8 @@ GEM
     arel (6.0.0)
     backports (3.6.4)
     builder (3.2.2)
+    byebug (4.0.5)
+      columnize (= 0.9.0)
     capybara (2.4.4)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -67,6 +69,8 @@ GEM
     childprocess (0.5.6)
       ffi (~> 1.0, >= 1.0.11)
     cliver (0.3.2)
+    coderay (1.1.0)
+    columnize (0.9.0)
     daemons (1.2.2)
     database_cleaner (1.4.1)
     erubis (2.7.0)
@@ -82,6 +86,7 @@ GEM
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
     log4r (1.1.10)
+    method_source (0.8.2)
     mime-types (2.4.3)
     mini_portile (0.6.2)
     minitest (5.5.1)
@@ -93,6 +98,13 @@ GEM
       cliver (~> 0.3.1)
       multi_json (~> 1.0)
       websocket-driver (>= 0.2.0)
+    pry (0.10.1)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    pry-byebug (3.1.0)
+      byebug (~> 4.0)
+      pry (~> 0.10)
     rack (1.6.0)
     rack-protection (1.5.3)
       rack
@@ -127,6 +139,7 @@ GEM
       sinatra (~> 1.3)
     sinatra-redirect-with-flash (0.2.1)
       sinatra (>= 1.0.0)
+    slop (3.6.0)
     term-ansicolor (1.3.0)
       tins (~> 1.0)
     thin (1.6.3)
@@ -153,5 +166,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  byebug
   edge!
   lt-core!
+  pry
+  pry-byebug

--- a/lib/lt/core/environment.rb
+++ b/lib/lt/core/environment.rb
@@ -113,9 +113,13 @@ module LT
     def require_env_specific_files
       # Note to future self: do not create production specific requirements
       if development? then
-        require 'pry'
-        require 'pry-stack_explorer'
-        require 'byebug'
+        %w(byebug pry pry-byebug).each do |dep|
+          begin
+            require dep
+          rescue LoadError
+            logger.info "#{dep} is not available and was not loaded."
+          end
+        end
       end
     end
 

--- a/lt-core.gemspec
+++ b/lt-core.gemspec
@@ -43,4 +43,9 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'selenium-webdriver', '>=2.43.0'
   spec.add_dependency 'capybara-webkit', '>=1.3.1'
   spec.add_dependency 'term-ansicolor', '>= 1.3.0'
+
+  # Dev dependencies.
+  spec.add_development_dependency 'byebug'
+  spec.add_development_dependency 'pry'
+  spec.add_development_dependency 'pry-byebug'
 end


### PR DESCRIPTION
A fix for the minor glitch referenced in learningtapestry/content@f3e6355d0a8a749d5e6718298ecba1450e032ca7.
- Require debugger gems if they're present
- Don't break otherwise
- Specify pry and byebug as development dependencies
