### PR TITLE
Remove debugger dependencies

### DIFF
--- a/lib/lt/core/environment.rb
+++ b/lib/lt/core/environment.rb
@@ -37,7 +37,6 @@ module LT
       env.configure_mailer if env.uses_mailer?
       env.configure_merchant if env.uses_merchant?
       env.load_all_models
-      env.require_env_specific_files
       env.logger.info("Core-app booted (mode: #{env.run_env})")
 
       LT.environment = env
@@ -107,15 +106,6 @@ module LT
       models.each do |file| 
         full_file =  File::join(model_path, File::basename(file))
         require full_file
-      end
-    end
-
-    def require_env_specific_files
-      # Note to future self: do not create production specific requirements
-      if development? then
-        require 'pry'
-        require 'pry-stack_explorer'
-        require 'byebug'
       end
     end
 
@@ -217,19 +207,6 @@ module LT
         self.logger.warn "Log4r configuration file not found, attempted: #{config_path + "/log4r.yml"}"
         self.logger.info "Log4r outputting to stdout with DEBUG level."
       end
-    end
-
-    # debug tools to permit running test code and having other parts of the application
-    # know to run a break point. This allows breaking out only during a specific test case
-    # even if the same point of code is accessed many times during the test.
-    def debug
-      @debug = true
-      yield
-      @debug = false
-    end
-    
-    def debug!
-      byebug if @debug
     end
 
     def mailer_config_path

--- a/lib/lt/tasks.rb
+++ b/lib/lt/tasks.rb
@@ -83,9 +83,13 @@ namespace :lt do
   end
 
   desc "Boot up a console with alternative ruby interactive 'pry'"
-  task :console_pry do
-    Rake::Task[:'lt:boot'].invoke
-    binding.pry
+  task :console_pry => [:boot] do
+    begin
+      require 'pry'; binding.pry
+    rescue LoadError
+      LT.env.logger.info('pry is not installed. Dropping into regular console.')
+      Rake::Task[:console].invoke
+    end
   end
 
   desc "Boot Core-app system"

--- a/lib/lt/test.rb
+++ b/lib/lt/test.rb
@@ -6,7 +6,6 @@ require 'capybara'
 require 'capybara/poltergeist'
 require 'capybara/webkit'
 require 'benchmark'
-require 'byebug'
 require 'lt/core'
 
 module LT


### PR DESCRIPTION
Removes dependencies on specific debugging gems.

This includes "assumed dependencies" which prevent
features from working if pry and byebug are not around.

`Environment#debug` and `Environment#debug!` were dropped.
Internal method `require_env_specific_files` was dropped.

Ref. https://github.com/learningtapestry/core/pull/4
