### PR TITLE
calc_env needs to come before Dotenv setup b/c setup_dotenv depends o…

### DIFF
--- a/lib/lt/core/environment.rb
+++ b/lib/lt/core/environment.rb
@@ -44,11 +44,11 @@ module LT
 
     def initialize(root_dir, env = nil)
       self.root_dir = File.expand_path(root_dir)
+      # calculate current run time environment
+      self.run_env = self.class.calc_env(env)
       # override ENV with Dotenv files
       setup_dotenv
       Dotenv.overload(global_env_path, specific_env_path, local_env_path)
-      # calculate current run time environment
-      self.run_env = self.class.calc_env(env)
       # set up internal state variables
       setup_environment
     end


### PR DESCRIPTION
on calc_env. We could call calc_env from setup_dotenv as an alternative, but I'm going with @deivid-rodriguez's rec and putting things in this order for now..
