### PR TITLE
Webapp: remove dependency on the login extension

### DIFF
--- a/lib/lt/webapp/base.rb
+++ b/lib/lt/webapp/base.rb
@@ -5,7 +5,6 @@ require 'sinatra/param'
 require 'sinatra/flash'
 require 'sinatra/redirect_with_flash'
 require_relative 'routes'
-require_relative 'login'
 require_relative 'views'
 
 module LT
@@ -52,7 +51,6 @@ module LT
       helpers Sinatra::RedirectWithFlash
 
       register LT::WebApp::Routes
-      register LT::WebApp::Login
       register LT::WebApp::Views
 
       # set up UI layout container

--- a/lib/lt/webapp/login.rb
+++ b/lib/lt/webapp/login.rb
@@ -37,13 +37,6 @@ module LT
         app.helpers Login::Helpers
         app.use Rack::Session::Cookie, :expire_after => 2592000, :secret => '3xWmSSa5X65Fyzn4jVwpM73zBtk5aXDn5CHuuQaB'
 
-        # Warden calls this method without actually redirecting here
-        # So the content of the page where login was attempted will
-        # be whatever is returned here
-        app.post app.vroute(:unauthenticated, '/unauthenticated') do
-          'Login failure here'
-        end
-
         app.use Warden::Manager do |manager|
           manager.default_strategies :password
           manager.failure_app = app


### PR DESCRIPTION
We're currently unable to override the `/unauthenticated` (login failure) route in RaiseYou because Warden is configured with the base `LT::WebApp` class as its `failure_app`. When creating an `/unauthenticated` route in RaiseYou, it gets ignored, even if `LT::WebApp::Login` doesn't define an `/unauthenticated` route at all, [because Warden invokes its `failure_app` directly](https://github.com/hassox/warden/blob/74162f2bf896b377472b6621ed1f6b40046525f4/lib/warden/manager.rb#L136).

AFAIK the only way to get around this is by registering `LT::WebApp::Login` inside the RaiseYou webapp class. This way the `failure_app` gets set to RaiseYou::WebApp, and we can create the `/unauthenticated` handler accordingly.

After merging this, we'll have to update all the apps that need login features to require and register `LT::WebApp::Login`.
